### PR TITLE
set connection request time out on default request config and socket timeout on default socket config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.cloudant</groupId> 
 	<artifactId>cloudant-client</artifactId>
-	<version>1.0.1</version>	
+	<version>1.0.2</version>
 	<packaging>jar</packaging>
 	<name>java-cloudant</name>
 	<description> official Cloudant Client for Java</description>

--- a/src/main/java/com/cloudant/client/api/CloudantClient.java
+++ b/src/main/java/com/cloudant/client/api/CloudantClient.java
@@ -456,7 +456,8 @@ public class CloudantClient {
 			props.setConnectionTimeout(connectOptions.getConnectionTimeout());
 			props.setSocketTimeout(connectOptions.getSocketTimeout());
 			props.setMaxConnections(connectOptions.getMaxConnections());
-			
+			props.setConnectionRequestTimeout(connectOptions.getConnectionRequestTimeout());
+
 			props.setProxyHost(connectOptions.getProxyHost());
 			props.setProxyPort(connectOptions.getProxyPort());
 			props.disableSSLAuthentication(connectOptions.isSSLAuthenticationDisabled());

--- a/src/main/java/com/cloudant/client/api/model/ConnectOptions.java
+++ b/src/main/java/com/cloudant/client/api/model/ConnectOptions.java
@@ -7,6 +7,8 @@ public class ConnectOptions {
 
 	private int socketTimeout;
 	private int connectionTimeout ;
+	private int connectionRequestTimeout;
+
 	private int maxConnections ;
 	
 	private String proxyHost ;
@@ -79,4 +81,18 @@ public class ConnectOptions {
 		return isSSLAuthenticationDisabled;
 	}
 
+	/** return connection request time out , how long request will wait to get connection from connection pool
+	 * @see #setConnectionRequestTimeout */
+	public int getConnectionRequestTimeout() {
+		return connectionRequestTimeout;
+	}
+
+	/** Sets connection request time out , how long request will wait to get connection from connection pool
+	 * @param connectionRequestTimeout set the time to wait for connection.
+	 * @return the updated {@link ConnectOptions} object.
+	 * @see #getConnectionRequestTimeout */
+	public ConnectOptions setConnectionRequestTimeout(int connectionRequestTimeout) {
+		this.connectionRequestTimeout = connectionRequestTimeout;
+		return this;
+	}
 }

--- a/src/main/java/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/org/lightcouch/CouchDbClient.java
@@ -44,6 +44,7 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.config.ConnectionConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -157,7 +158,9 @@ public class CouchDbClient extends  CouchDbClientBase {
 							.setCharset(Consts.UTF_8).build())
 					.setDefaultRequestConfig(RequestConfig.custom()
 							.setSocketTimeout(props.getSocketTimeout())
-							.setConnectTimeout(props.getConnectionTimeout()).build());
+							.setConnectTimeout(props.getConnectionTimeout()).build())
+					.setDefaultSocketConfig(SocketConfig.custom()
+							.setSoTimeout(props.getSocketTimeout()).build());
 			if (props.getProxyHost() != null) 
 				clientBuilder.setProxy(new HttpHost(props.getProxyHost(), props.getProxyPort()));
 			clientBuilder.setDefaultCookieStore(cookies); // use AUTH cookies

--- a/src/main/java/org/lightcouch/CouchDbClient.java
+++ b/src/main/java/org/lightcouch/CouchDbClient.java
@@ -158,10 +158,11 @@ public class CouchDbClient extends  CouchDbClientBase {
 							.setCharset(Consts.UTF_8).build())
 					.setDefaultRequestConfig(RequestConfig.custom()
 							.setSocketTimeout(props.getSocketTimeout())
-							.setConnectTimeout(props.getConnectionTimeout()).build())
-					.setDefaultSocketConfig(SocketConfig.custom()
+							.setConnectTimeout(props.getConnectionTimeout())
+							.setConnectionRequestTimeout(props.getConnectionRequestTimeout()).build()
+					).setDefaultSocketConfig(SocketConfig.custom()
 							.setSoTimeout(props.getSocketTimeout()).build());
-			if (props.getProxyHost() != null) 
+			if (props.getProxyHost() != null)
 				clientBuilder.setProxy(new HttpHost(props.getProxyHost(), props.getProxyPort()));
 			clientBuilder.setDefaultCookieStore(cookies); // use AUTH cookies
 			if (props.getUsername() != null) {

--- a/src/main/java/org/lightcouch/CouchDbProperties.java
+++ b/src/main/java/org/lightcouch/CouchDbProperties.java
@@ -37,6 +37,7 @@ public class CouchDbProperties {
 	// optional
 	private int socketTimeout;
 	private int connectionTimeout;
+	private int connectionRequestTimeout;
 	private int maxConnections;
 	private String proxyHost;
 	private int proxyPort;
@@ -192,4 +193,18 @@ public class CouchDbProperties {
 		return disableSSLAuthentication;
 	}
 
+	/** return connection request time out , how long request will wait to get connection from connection pool
+	 * @see #setConnectionRequestTimeout */
+	public int getConnectionRequestTimeout() {
+		return connectionRequestTimeout;
+	}
+
+	/** Sets connection request time out , how long request will wait to get connection from connection pool
+	 * @param connectionRequestTimeout set the time to wait for connection.
+	 * @return the updated {@link CouchDbProperties} object.
+	 * @see #getConnectionRequestTimeout */
+	public CouchDbProperties setConnectionRequestTimeout(int connectionRequestTimeout) {
+		this.connectionRequestTimeout = connectionRequestTimeout;
+		return this;
+	}
 }


### PR DESCRIPTION
add property connectionRequestTimeout to clouadant ConnectOptions and CouchDbProperties
set connection request time out on default request config , to prevent request from waiting for connection for long time

and socket timeout on default socket config , request can hang during ssl handshake if no time out is set